### PR TITLE
Gnina v1.3 support

### DIFF
--- a/MetaScreener/cluster_nodes/execute_scripts/scriptGN.sh
+++ b/MetaScreener/cluster_nodes/execute_scripts/scriptGN.sh
@@ -3,7 +3,7 @@
 #   Author: Jochem Nelen
 #   Author: Carlos Martinez Cortes
 #   Email:  cmartinez1@ucam.edu
-#   Description: Docking with Vina
+#   Description: Docking with Gnina
 # ______________________________________________________________________________________________________________________
 
 vGauss1=-0.035579
@@ -71,8 +71,8 @@ function create_out()
 	
 	### ADD CNN scoring
 	minimizedAffinity=$(grep '    1 ' ${out_aux}.ucm | awk '{print $2}')
-	CNNscore=$(grep '    1 ' ${out_aux}.ucm | awk '{print $3}')
-	CNNaffinity=$(grep '    1 ' ${out_aux}.ucm | awk '{print $4}')
+	CNNscore=$(grep '    1 ' ${out_aux}.ucm | awk '{print $4}')
+	CNNaffinity=$(grep '    1 ' ${out_aux}.ucm | awk '{print $5}')
 	global_score=${minimizedAffinity}
 
 	CNNscores=${minimizedAffinity}:${CNNscore}:${CNNaffinity}

--- a/MetaScreener/cluster_nodes/standar_out_put.py
+++ b/MetaScreener/cluster_nodes/standar_out_put.py
@@ -76,6 +76,7 @@ if data_json["software"] == "GN":
 	
 	data_json["CNNscore"] = CNNscore
 	data_json["CNNAffinity"] = CNNaffinity
+	data_json["CNN_VS"] = str(round(float(CNNscore) * float(CNNaffinity), 3))
 
 	data_json["global_score"] = minimizedAffinity
 

--- a/MetaScreener/cluster_nodes/templates_queue/codigo.sh
+++ b/MetaScreener/cluster_nodes/templates_queue/codigo.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+if [[ "${software}" == "GN" ]]; then
+  echo "export OMP_NUM_THREADS=1 "																			>>$name_template_job
+  echo "export MKL_NUM_THREADS=1 "																			>>$name_template_job
+  echo "export OPENBLAS_NUM_THREADS=1 "																			>>$name_template_job
+fi
+
 echo "echo \"start job\" 1>&2" 																			>>$name_template_job
 echo "date +\"%s   %c\" 1>&2"																			>>$name_template_job
 
@@ -14,13 +20,14 @@ fi
 path_singularity=$(dirname ${path_metascreener})"/singularity/"
 
 singularity_image="${path_singularity}metascreener.simg"
-if [[ "${software}" == "EO" ]] ||[[ "${software}" == "RC" ]] || [[ "${software}" == "OM" ]] ; then
+if [[ "${software}" == "EO" ]] ||[[ "${software}" == "RC" ]] || [[ "${software}" == "OM" ]] || [[ "${software}" == "GN" ]] ; then
   singularity_image="${path_singularity}metascreener_22.04.simg"
 fi
 
 singularity_prefix=""
+
 if [[ "${software}" == "GN" && "${GPU}" != "N/A" ]]; then
-  singularity_prefix="--nv"
+  singularity_prefix+="--nv "
 fi
 
 echo $modules_metascreener >>$name_template_job
@@ -35,7 +42,4 @@ echo "singularity exec ${singularity_prefix} --bind $bind ${singularity_image} $
 echo "mv $name_template_job ${folder_jobs_done}"                                                        >>$name_template_job
 
 echo "echo \"end job\" 1>&2" 																			>>$name_template_job
-echo "date +\"%s   %c\" 1>&2"																			>>$name_template_job
-
-
-
+echo "date +\"%s   %c\" 1>&2" 																			>>$name_template_job	

--- a/MetaScreener/external_sw/gnina/readme.txt
+++ b/MetaScreener/external_sw/gnina/readme.txt
@@ -1,0 +1,1 @@
+Download Gnina v1.3 here: https://github.com/gnina/gnina/releases/download/v1.3/gnina

--- a/MetaScreener/login_node/templateParams/templateGN.txt
+++ b/MetaScreener/login_node/templateParams/templateGN.txt
@@ -7,7 +7,7 @@
 #LanzCoordY:
 #LanzCoordZ:
 #LanzGrid:N
-#LanzCores:auto ## Without a GPU, "auto" will default to 1 core per job, with a GPU this will be 4 cores
+#LanzCores:4
 #LanzTimeExecution:900
 #LanzMem:2G
 #lanzSizeGridX:30

--- a/MetaScreener/login_node/verify_input_data.sh
+++ b/MetaScreener/login_node/verify_input_data.sh
@@ -377,14 +377,6 @@ if [[ ${software} == "GN" ]]; then
     echo -e "${RED} Error: ${ext_sw}gnina/gnina doesn't exist. Download the executable to this directory, give it execution permissions and try again.${NONE}"
     exit 1
   fi
-  
-  if [[ ! "${cores%% *}" =~ ^[0-9]+$ ]]; then
-    if [[ "${GPU}" != "N/A" ]]; then
-      cores=4
-    else
-      cores=1
-    fi
-  fi
 fi
 
 if [[ ${software} == "LS" ]] ;then

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ rm singularity/singularity.zip
 ### Available Software
 1. **AD AutoDock Vina** 1.1.2 (May 11, 2011):
    Open source. https://github.com/ccsb-scripps/AutoDock-Vina.
-2. **GN Gnina** v1.0.3 (Feb 11, 2023):  
+2. **GN Gnina** v1.3 (Oct 4, 2024):  
    Open source. https://github.com/gnina/gnina.  
-   Download the executable to metascreener/MetaScreener/external_sw/gnina/ and give execution permissions.                               
+   Download the [executable](https://github.com/gnina/gnina/releases/tag/v1.3) to metascreener/MetaScreener/external_sw/gnina/ and give execution permissions.                               
 4. **LF Lead Finder** version 2104 build 1, 18 April 2021: 
    Commercial software. License and software required (copy to "metascreener/MetaScreener/external_sw/leadFinder/").
    You can get an Academic license at http://www.moltech.ru/leadfinder/versions.html.

--- a/singularity/metascreener_22.04.def
+++ b/singularity/metascreener_22.04.def
@@ -1,20 +1,20 @@
 Bootstrap: docker
-From: ubuntu:22.04
+From: nvidia/cuda:12.0.0-devel-ubuntu22.04
 
 %runscript
     echo "Singularity image for Ubuntu 22.04 in MetaScreener"
 
 %post
     # Install build dependencies
-    apt-get update && apt-get install -y build-essential libssl-dev uuid-dev git libgpgme-dev squashfs-tools libseccomp-dev pkg-config curl libpciaccess0 libglib2.0-dev libfuse3-dev autoconf libtool
+    apt-get update && apt-get install -y build-essential libssl-dev uuid-dev git libgpgme-dev squashfs-tools libseccomp-dev pkg-config curl libpciaccess0 libglib2.0-dev libfuse3-dev autoconf libtool python3 time
 
     # Check if all dependencies are installed
     apt-get install -y --no-install-recommends checkinstall
 
-    # Download and install Go 1.20
-    curl -L -o /usr/local/go1.20.linux-amd64.tar.gz https://golang.org/dl/go1.20.linux-amd64.tar.gz
-    tar -C /usr/local -xzf /usr/local/go1.20.linux-amd64.tar.gz
-    rm /usr/local/go1.20.linux-amd64.tar.gz
+    # Download and install Go 1.24.1
+    curl -L -o /usr/local/go1.24.1.linux-amd64.tar.gz https://go.dev/dl/go1.24.1.linux-amd64.tar.gz
+    tar -C /usr/local -xzf /usr/local/go1.24.1.linux-amd64.tar.gz
+    rm /usr/local/go1.24.1.linux-amd64.tar.gz
     export PATH=$PATH:/usr/local/go/bin
 
     # Set the Go environment variables
@@ -30,13 +30,14 @@ From: ubuntu:22.04
     git submodule update --init --recursive
 
     # Clean and rebuild Singularity
-    ./mconfig
+    ./mconfig --without-libsubid
     make -C builddir
     make -C builddir install
 
     # Verify build logs
     make -C builddir > build_log.txt 2>&1
 
+    ln -s /usr/bin/python3 /usr/bin/python
     apt-get clean
 
 %environment
@@ -46,4 +47,3 @@ From: ubuntu:22.04
 %labels
     AUTHOR Carlos Martinez Cortes (cmartinez1@ucam.edu)
     Version v1
-


### PR DESCRIPTION
This PR adds Gnina v1.3 support.

It took some time tuning the performance to be as efficient as possible, but I think I got there now (oddly enough, by setting OMP_NUM_THREADS=1, performance is the fastest and most efficient). To upgrade, users should just upgrade the gnina executable to version v1.3, and everything should work out of the box (and a lot faster than before!).

Something we still need to do is update the singularity image (metascreener_22.04.simg) in the google drive. It is quite a bit larger now since it now includes cuda dependencies. We could also consider to split it completely. Either way, I had to update the def file of the singularity image since now a higher version of Go is required. 